### PR TITLE
fix: statusBarStyle设置后全局生效，不能单独设置

### DIFF
--- a/Source/BMManager/StartConfig/BMPlatformModel.h
+++ b/Source/BMManager/StartConfig/BMPlatformModel.h
@@ -13,6 +13,7 @@
 @property (nonatomic, copy) NSString *mediatorPage;     /**< 中介者页面js路径 */
 @property (nonatomic, copy) NSString *navBarColor;      /**< 导航栏默认颜色 */
 @property (nonatomic, copy) NSString *navItemColor;     /**< 导航栏item颜色 */
+@property (nonatomic, copy) NSString *statusBarStyle;   /**< 状态栏文字颜色 */
 @end
 
 @interface BMPlatformModelUrl : NSObject

--- a/Source/ErosApp/ViewControllerExtend/BMBaseViewController+Order.m
+++ b/Source/ErosApp/ViewControllerExtend/BMBaseViewController+Order.m
@@ -31,8 +31,14 @@
 /* 设置状态栏样式 */
 - (void)bmSetStatusBarStyle
 {
-    
-    if (!self.routerModel.statusBarStyle) return;
+    if (!self.routerModel.statusBarStyle) {
+        if ([BMConfigManager.shareInstance.platform.page.statusBarStyle isEqualToString:@"LightContent"]) {
+            [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent animated:NO];
+        } else {
+            [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault animated:NO];
+        }
+        return;
+    }
     
     /* 设置状态栏 字体颜色 */
     if ([self.routerModel.statusBarStyle isEqualToString:@"Default"]) {


### PR DESCRIPTION
最好在 `eros.native.js` 中增加 `page.statusBarStyle`，这样方便定制状态栏文字颜色